### PR TITLE
Continue in loop when the pilot is not relevant

### DIFF
--- a/src/composables/airport.ts
+++ b/src/composables/airport.ts
@@ -82,6 +82,8 @@ export const getAircraftForAirport = (data: Ref<StoreOverlayAirport['data']>, fi
         } satisfies AirportPopupPilotList;
 
         for (const pilot of dataStore.vatsim.data.pilots.value) {
+            if (data.value.icao !== pilot.departure && data.value.icao !== pilot.arrival) continue;
+
             let distance = 0;
             let flown = 0;
             let eta: Date | null = null;
@@ -122,6 +124,7 @@ export const getAircraftForAirport = (data: Ref<StoreOverlayAirport['data']>, fi
         }
 
         for (const pilot of dataStore.vatsim.data.prefiles.value) {
+            if (pilot.departure !== data.value.icao) continue;
             if (vatAirport.aircraft.prefiles?.includes(pilot.cid)) {
                 list.prefiles.push({
                     ...pilot,


### PR DESCRIPTION
I think especially the first new line should improve the performance quite a bit.
At the moment if i am not wrong all the calculation for the pilot is done, even when it is not relevant for the airport.
With this push request we continue if the pilot is not relevant for our airport.