### PR TITLE
Disposing lines and setting var to undefined

### DIFF
--- a/src/components/map/aircraft/MapAircraft.vue
+++ b/src/components/map/aircraft/MapAircraft.vue
@@ -343,19 +343,7 @@ async function toggleAirportLines(value = canShowLines.value) {
     if (!canShowLines.value) return;
 
     if (turns) {
-        if (depLine) {
-            depLine.dispose();
-            linesSource.value?.removeFeature(depLine);
-            depLine = undefined;
-        }
-
-        if (arrLine) {
-            arrLine.dispose();
-            linesSource.value?.removeFeature(arrLine);
-            arrLine = undefined;
-        }
-
-        clearLineFeatures();
+        clearLines();
 
         turns.features.forEach((feature, index) => {
             const prevFeature = turns.features[index - 1];
@@ -507,8 +495,16 @@ async function toggleAirportLines(value = canShowLines.value) {
 
 function clearLines() {
     clearLineFeatures();
-    if (depLine) linesSource.value?.removeFeature(depLine);
-    if (arrLine) linesSource.value?.removeFeature(arrLine);
+    if (depLine) {
+        depLine.dispose();
+        linesSource.value?.removeFeature(depLine);
+        depLine = undefined;
+    }
+    if (arrLine) {
+        arrLine.dispose();
+        linesSource.value?.removeFeature(arrLine);
+        arrLine = undefined;
+    }
 }
 
 function clearAll() {


### PR DESCRIPTION
### 🔗 Your VATSIM ID

-

### 🔗 Linked Issue

-

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [x] 🐞 Bug fix
- [ ] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

When not using turns and straight lines instead to departure and destination airport, the line was only drawn during the first hover and wasn't working during the next hover, because the features were removed from the layer and never added again.
In the turn function it was removed and reset, because of this it is working when using turns.
With this change the lines are always disposed and newly generated.
In the turns part we now call clearLines, because this function includes the call of clearLineFeatures
