### PR TITLE
Only skip the current pilot if he has a flight plan

### DIFF
--- a/src/composables/airport.ts
+++ b/src/composables/airport.ts
@@ -82,7 +82,7 @@ export const getAircraftForAirport = (data: Ref<StoreOverlayAirport['data']>, fi
         } satisfies AirportPopupPilotList;
 
         for (const pilot of dataStore.vatsim.data.pilots.value) {
-            if (data.value.icao !== pilot.departure && data.value.icao !== pilot.arrival) continue;
+            if (pilot.departure && pilot.arrival && data.value.icao !== pilot.departure && data.value.icao !== pilot.arrival) continue;
 
             let distance = 0;
             let flown = 0;


### PR DESCRIPTION
### 🔗 Your VATSIM ID

<!-- If your PR has an issue, please specify it like Closes #123 -->


<!-- If your PR has an issue, please specify it like Closes #123 -->


<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [x] 🐞 Bug fix
- [ ] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

Only skip the current pilot if he has a flight plan. Pilots without flight plan will be in vatAirport.aircraft.groundDep array even if they do not have a flight plan.
