### PR TITLE
Replace QuestionIcon with DocsIcon for documentation button

### DIFF
--- a/app/assets/icons/basic/docs.svg
+++ b/app/assets/icons/basic/docs.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+  <polyline points="14 2 14 8 20 8"/>
+  <line x1="16" y1="13" x2="8" y2="13"/>
+  <line x1="16" y1="17" x2="8" y2="17"/>
+  <polyline points="10 9 9 9 8 9"/>
+</svg>

--- a/app/components/views/header/ViewHeader.vue
+++ b/app/components/views/header/ViewHeader.vue
@@ -170,7 +170,7 @@
                             type="secondary"
                         >
                             <template #icon>
-                                <question-icon/>
+                                <docs-icon/>
                             </template>
                         </common-button>
                     </template>
@@ -275,7 +275,7 @@ import { useStore } from '~/store';
 import DiscordIcon from 'assets/icons/header/discord.svg?component';
 import GithubIcon from 'assets/icons/header/github.svg?component';
 import SettingsIcon from 'assets/icons/kit/settings.svg?component';
-import QuestionIcon from 'assets/icons/basic/question.svg?component';
+import DocsIcon from 'assets/icons/basic/docs.svg?component';
 import CommonButton from '~/components/common/basic/CommonButton.vue';
 import ArrowTopIcon from 'assets/icons/kit/arrow-top.svg?component';
 import SearchIcon from 'assets/icons/kit/search.svg?component';


### PR DESCRIPTION
### 🔗 1769455

<!-- Please specify your CID -->

### 🔗 No Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] 🐞 Bug fix
- [x] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

Replace `QuestionIcon` with `DocsIcon` in ViewHeader component for better semantic clarity. The documentation button now displays a document icon instead of a question mark icon, which more accurately represents its purpose of linking to documentation.

**Changes:**
- Added new `docs.svg` icon to `app/assets/icons/basic/`
- Updated `ViewHeader.vue` to use `DocsIcon` component instead of `QuestionIcon`
- Updated import statement to reference the new icon component

I have been confused by this icon for a long time. Changing to a docs icon could more clearly represent the type of website it directs to. If it's a question mark, many people will think of it as a Q&A.

---

No conflicts and ready to merge.