### PR TITLE
added some more VACC's/ARTCC's to the allowedDomains

### DIFF
--- a/app/composables/atc.ts
+++ b/app/composables/atc.ts
@@ -182,6 +182,7 @@ const allowedDomains = [
     'idvacc.id',
     'zjxartcc.org',
     'twitch.tv',
+    'map.vatsim.net',
 ];
 
 function addATISLinks(lines: string[]) {


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1606995

### 🔗 Linked Issue

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] 🐞 Bug fix
- [x] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

<!-- Tell us more about your PR -->
Added some more VACC's and ARTCC's to the allowedDomains list (basically went over whoever was online and added their website to the list): 
'chartfox.org',
'vatsim.uk',
'vatsim.fr',
'vatadria.com',
'rovacc.ro',
'idvacc.id',
'zjxartcc.org',
'twitch.tv',