### PR TITLE
Added VATUSA ARTCC domains

### DIFF
--- a/app/composables/atc.ts
+++ b/app/composables/atc.ts
@@ -192,7 +192,6 @@ const allowedDomains = [
     'clevelandcenter.org',
     'zdvartcc.org',
     'zfwartcc.net',
-    'vhcf.net',
     'houston.center',
     'flyindycenter.com',
     'zkcartcc.org',


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1897191


### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] 🐞 Bug fix
- [x] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description
This adds the VATUSA subdivision domains. These are typically the ones used for feedback.
