### PR TITLE
hiding sectors when zooming in

### DIFF
--- a/app/components/map/sectors/MapSectorsList.vue
+++ b/app/components/map/sectors/MapSectorsList.vue
@@ -200,7 +200,7 @@ watch(() => mapStore.distance.pixel, val => {
 
 const hideAtc = computed(() => isHideAtcType('firs'));
 
-watch([emptyFirsList, vectorSource, hideAtc, hideOnZoom], processEmptyFirs, {
+watch([emptyFirsList, vectorSource, hideAtc], processEmptyFirs, {
     immediate: true,
 });
 


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1489535

### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] 🐞 Bug fix
- [x] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

Hide center/APP sectors on zoom in
