### PR TITLE
Add SCT/ZLA to ATC Duplicating

### DIFF
--- a/app/utils/backend/vatsim/atc-duplicating.ts
+++ b/app/utils/backend/vatsim/atc-duplicating.ts
@@ -57,10 +57,10 @@ export const duplicatingSettings = [
             JRV: 'RIC_APP',
         },
     },
-     /**
-     * @description ZLA/SCT/L30 Area/TRACON
-     * @author 845421
-     */
+    /**
+    * @description ZLA/SCT/L30 Area/TRACON
+    * @author 845421
+    */
     {
         regex: /^(SCT|LAX|BUR|ONT|SNA|PSP|SAN|LAS|ZLA)(_\w{0,3})?_(APP|DEP|CTR|TMU)$/,
         mapping: {


### PR DESCRIPTION
Adds definitions for sectorizing in SCT, L30, and ZLA.

### 🔗 Your VATSIM ID

845421

### 🔗 Linked Issue


### ❓ Type of change

Adds SCT/ZLA to duplicating feature.

- [ ] 🐞 Bug fix
- [X] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

Adds the dashed line ATC duplicating feature for ZLA.