### PR TITLE
Fix pilot name formatting (fixes #1302)

### DIFF
--- a/app/components/map/airports/MapAirportCounts.vue
+++ b/app/components/map/airports/MapAirportCounts.vue
@@ -81,7 +81,7 @@
                                 v-else-if="item === pilot.name"
                                 type="pilot"
                             >
-                                {{ pilot.name }}
+                                {{ parseEncoding(pilot.name) }}
                             </common-spoiler>
                             <div
                                 v-else
@@ -108,6 +108,7 @@ import CommonInfoBlock from '~/components/common/blocks/CommonInfoBlock.vue';
 import type { PartialRecord } from '~/types';
 import type { VatsimShortenedAircraft, VatsimShortenedPrefile } from '~/types/data/vatsim';
 import { useStore } from '~/store';
+import { parseEncoding } from '~/utils/data';
 import CommonSpoiler from '~/components/common/vatsim/CommonSpoiler.vue';
 
 const props = defineProps({

--- a/app/pages/pilots.vue
+++ b/app/pages/pilots.vue
@@ -55,7 +55,7 @@
                             {{ pilot.callsign }}
                         </td>
                         <td>
-                            {{ pilot.name }}
+                            {{ parseEncoding(pilot.name) }}
                         </td>
                         <td>
                             {{ pilot.altitude }}
@@ -86,6 +86,7 @@
 <script setup lang="ts">
 import CommonPageBlock from '~/components/common/blocks/CommonPageBlock.vue';
 import type { VatsimExtendedPilot } from '~/types/data/vatsim';
+import { parseEncoding } from '~/utils/data';
 import CommonToggle from '~/components/common/basic/CommonToggle.vue';
 
 const { data: pilots, refresh } = useAsyncData('sup-pilots', () => $fetch<VatsimExtendedPilot[]>('/api/data/vatsim/data/pilots'));


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1849614

### 🔗 Linked Issue

Closes #1302

### ❓ Type of change

- [x] 🐞 Bug fix
- [ ] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

Fixes the strange formatting of pilot names, e.g. names containing 'ã' turning into 'Ã£'
