### PR TITLE
Add ZHU TRACONs to ATC duplicating settings

### DIFF
--- a/app/utils/backend/vatsim/atc-duplicating.ts
+++ b/app/utils/backend/vatsim/atc-duplicating.ts
@@ -57,4 +57,20 @@ export const duplicatingSettings = [
             JRV: 'RIC_APP',
         },
     },
+    /**
+     * @description ZHU TRACONs
+     * @author 1010912
+     */
+    {
+        regex: /^HOU_\d{2}_CTR$/,
+        mapping: {
+            BTR: 'BTR_APP',
+            CRP: 'CRP_APP',
+            MSY: 'MSY_APP',
+            LCH: 'LCH_APP',
+            LFT: 'LFT_APP',
+            GPT: 'GPT_APP',
+            MOB: 'MOB_APP',
+        },
+    },    
 ] satisfies DuplicatingSetting[];


### PR DESCRIPTION
Added ZHU TRACON mapping for Houston Center.

### 🔗 Your VATSIM ID

1010912

### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] 🐞 Bug fix
- [X] 👌 Enhancement (improve something existing)
- [X] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

Experimenting with the new duplicate ATC positions to show TRACON ownership by overlaying enroute controllers.