### PR TITLE
Add LECB Area mapping to ATC duplication settings

### DIFF
--- a/app/utils/backend/vatsim/atc-duplicating.ts
+++ b/app/utils/backend/vatsim/atc-duplicating.ts
@@ -89,8 +89,8 @@ export const duplicatingSettings = [
     {
         regex: /^LECB_RW\d?_CTR$/,
         mapping: {
-            'BCN': 'LEBL_APP',
-            'LEIB': 'LEIB_APP',
+            BCN: 'LEBL_APP',
+            LEIB: 'LEIB_APP',
         },
     },
 ] satisfies DuplicatingSetting[];


### PR DESCRIPTION
Added LECB Area mapping for ATC duplication settings.

### 🔗 Your VATSIM ID

<!-- Please specify your CID -->
1558357

### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->
None

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] 🐞 Bug fix
- [x] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

<!-- Tell us more about your PR -->
Add support for LECB area in ATC duplication