### PR TITLE
Add ZHU Center and TRACONs to ATC duplication

### DIFF
--- a/app/utils/backend/vatsim/atc-duplicating.ts
+++ b/app/utils/backend/vatsim/atc-duplicating.ts
@@ -161,5 +161,5 @@ export const duplicatingSettings = [
             NQI: 'NQI_APP',
             POE: 'POE_APP',
         },
-    },    
+    }
 ] satisfies DuplicatingSetting[];


### PR DESCRIPTION
Added ZHU Center and TRACONs mapping for ATC duplication.

### 🔗 Your VATSIM ID

1010192

### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] 🐞 Bug fix
- [X] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

Add ZHU enroute duplication to underlying TRACONs