### PR TITLE
Update ZDC Center and PCT area duplication to include ZDC TRACONs

### DIFF
--- a/app/utils/backend/vatsim/atc-duplicating.ts
+++ b/app/utils/backend/vatsim/atc-duplicating.ts
@@ -45,16 +45,23 @@ export const duplicatingSettings = [
         },
     },
     /**
-     * @description ZDC PCT
+     * @description ZDC Center and PCT
      * @author 1652726
      */
     {
         regex: /^(PCT|IAD|DCA|BWI|RIC|DC)(_\w{0,3})?_(APP|DEP|CTR)$/,
         mapping: {
+            PCT: 'PCT_APP',
             SHD: 'IAD_APP',
             CHP: 'BWI_APP',
             MTV: 'DCA_APP',
             JRV: 'RIC_APP',
+            ORF: 'ORF_APP',
+            RDU: 'RDU_APP',
+            ROA: 'ROA_APP',
+            ACY: 'ACY_APP',
+            ILM: 'ILM_APP',
+            FAY: 'FAY_APP',
         },
     },
     /**


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1652726

### ❓ Type of change

- [ ] 🐞 Bug fix
- [x] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

Updated the ZDC PCT Area duplication to now include TRACONs covered by ZDC. This is to provide more situational awareness to pilots when ZDC Center is split.
