### PR TITLE
Added vatspy data matching by aeronav positions as fallback

### DIFF
--- a/app/utils/data/vatsim.ts
+++ b/app/utils/data/vatsim.ts
@@ -160,6 +160,19 @@ function findUirOrFir(splittedName: string[], atc: VatsimShortenedController, ui
                 if (feature.length) break;
             }
         }
+
+        // We try to find the correct FIR by getting the normal station name from the aeronavPosition database. This if for cases when the controller logs in with a slightly different callsign, like for example EDGG_D8B_CTR, but the callsign of the vatspy data is EDGG_DKB_CTR
+        if (!feature.length) {
+            let matchingPosition = null;
+            if (radarStorage.aeronavPositions) {
+                matchingPosition = radarStorage.aeronavPositions.find(x => x.fir === firstName && x.freq === atc.frequency);
+            }
+            if (matchingPosition) {
+                const matchingCallsign = matchingPosition.fir + '_' + matchingPosition.ml;
+                feature = findFacility(matchingCallsign, atc);
+            }
+        }
+
         if (!feature.length) feature = findFacility(firstName, atc);
         return feature;
     }

--- a/app/utils/server/storage.ts
+++ b/app/utils/server/storage.ts
@@ -229,6 +229,12 @@ export interface RadarStorage {
         dynamicData: VatglassesDynamicAPIData;
         activeData: string | null;
     };
+    aeronavPositions:
+    {
+        fir: string; // the start of the login callsign
+        ml: string; // middle latter of the login callsign
+        freq: string; // frequency
+    }[];
     vatsimStatic: {
         divisions: VatsimDivision[];
         subDivisions: VatsimSubDivision[];
@@ -263,6 +269,7 @@ export const radarStorage: RadarStorage = {
         },
         activeData: null,
     },
+    aeronavPositions: [],
     vatsimStatic: {
         divisions: [],
         subDivisions: [],


### PR DESCRIPTION
### 🔗 Your VATSIM ID

<!-- Please specify your CID -->

### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] 🐞 Bug fix
- [x] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

I have added a fallback for matching the vatspy sectors. If for a callsign not mathing entry is found in the vatspy data, we now check by the frequency whether the controller has loged in with a non-standard login for the frequency he uses.