### PR TITLE
Showing sectors in BookingOverride mode

### DIFF
--- a/app/components/map/sectors/MapSectorsList.vue
+++ b/app/components/map/sectors/MapSectorsList.vue
@@ -120,7 +120,7 @@ const vatGlassesCombinedActive = computed(() => store.mapSettings.vatglasses?.co
 
 const facilities = useFacilitiesIds();
 
-const bookingsData = computed(() => ((store.mapSettings.visibility?.bookings ?? true) && !store.config.hideBookings) ? store.bookings.filter(x => x.atc.facility === facilities.CTR) : []);
+const bookingsData = computed(() => (((store.mapSettings.visibility?.bookings ?? true) && !store.config.hideBookings) || store.bookingOverride) ? store.bookings.filter(x => x.atc.facility === facilities.CTR) : []);
 
 const firs = computed(() => {
     interface Fir {


### PR DESCRIPTION
### 🔗 Your VATSIM ID

<!-- Please specify your CID -->

### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [x] 🐞 Bug fix
- [ ] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

Currently if you have the setting Visibility -> Show Bookings off, the CTR sectors are not shown on the map with booking override. With this fix, CTRs are shown even when Show Bookings is off.