### PR TITLE
Add VLY_X_APP to ATC duplicating mappings

### DIFF
--- a/app/utils/server/vatsim/atc-duplicating.ts
+++ b/app/utils/server/vatsim/atc-duplicating.ts
@@ -151,6 +151,7 @@ export const duplicatingSettings = [
             AUS: 'AUS_W_APP',
             BTR: 'BTR_W_APP',
             CRP: 'CRP_N_APP',
+            VLY: 'VLY_X_APP',
             GPT: 'GPT_W_APP',
             LCH: 'LCH_E_APP',
             LFT: 'LFT_W_APP',


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1010912

### 🔗 Linked Issue


### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] 🐞 Bug fix
- [X] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

Missed a TRACON in my first run of ATC Duplication rules.