### PR TITLE
Add MHCC_CTR mapping for ATC duplicating settings

### DIFF
--- a/app/utils/server/vatsim/atc-duplicating.ts
+++ b/app/utils/server/vatsim/atc-duplicating.ts
@@ -229,7 +229,7 @@ export const duplicatingSettings = [
     },
         /**
      * @description MHCC_CTR And Tracoons
-     * @author vatsim ID
+     * @author 1794201 and 1753002
      */
     {
         regex: /^MHCC(_\w{0,3})?_CTR$/,


### PR DESCRIPTION
Added a new mapping for MHCC_CTR and Tracoons with various airport codes.

### 🔗 Your VATSIM ID

1794201 - 1753002

### 🔗 Linked Issue

### ❓ Type of change

- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ x] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

Add sector duplications for MHCC_CTR
