### PR TITLE
Update regex for LECB area in ATC duplication

### DIFF
--- a/app/utils/server/vatsim/atc-duplicating.ts
+++ b/app/utils/server/vatsim/atc-duplicating.ts
@@ -134,7 +134,7 @@ export const duplicatingSettings = [
     * @author 1558357
     */
     {
-        regex: /^LECB_RW\d?_CTR$/,
+        regex: /^LECB_(?:RW[\d_]?|LLI|PPI)_CTR$/,
         mapping: {
             BCN: 'LEBL_APP',
             LEIB: 'LEIB_APP',


### PR DESCRIPTION
### 🔗 Your VATSIM ID

<!-- Please specify your CID -->
1558357

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [x] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

<!-- Tell us more about your PR -->
This PR updates the regex for LECB Area so that LECB_LLI_CTR and LECB_PPI_CTR also gets recognised.