### PR TITLE
Add ZDV mapping for ATC Duplication

### DIFF
--- a/app/utils/server/vatsim/atc-duplicating.ts
+++ b/app/utils/server/vatsim/atc-duplicating.ts
@@ -266,10 +266,10 @@ export const duplicatingSettings = [
             CPR: 'CPR_APP',
         },
     },
-     /**
-     * @description CZYZ FIR Terminal Sectors
-     * @author 1401686 and 1448618
-     */
+    /**
+    * @description CZYZ FIR Terminal Sectors
+    * @author 1401686 and 1448618
+    */
     {
         regex: /^TOR(_\w{0,3})?_(DEP|APP|CTR)$/,
         mapping: {


### PR DESCRIPTION
### 🔗 Your VATSIM ID

`1378019`

### 🔗 Linked Issue

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [x] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

Adds Denver Center and D01 TRACON ATC Duplication Regex in line with other existing ARTCCs
