### PR TITLE
Add ZAU Center and TRACONs to ATC duplication

### DIFF
--- a/app/utils/server/vatsim/atc-duplicating.ts
+++ b/app/utils/server/vatsim/atc-duplicating.ts
@@ -249,4 +249,25 @@ export const duplicatingSettings = [
             SJO: 'MROC_C_APP',
         },
     },
+    /**
+     * @description ZAU Center and TRACONs
+     * @author 1634151
+     */
+    {
+        regex: /^CHI_\d{2}_CTR$/,
+        mapping: {
+            C90: 'CHI_Z_APP',
+            AZO: 'AZO_G_APP',
+            CID: 'CID_S_APP',
+            CMI: 'CMI_E_APP',
+            FWA: 'FWA_W_APP',
+            MKE: 'MKE_E_APP',
+            MLI: 'MLI_N_APP',
+            MSN: 'MSN_W_APP',
+            RFD: 'RFD_E_APP',
+            SBN: 'SBN_N_APP',
+            GUS: 'GUS_E_APP',
+            VOK: 'VOK_APP',
+        },
+    },
 ] satisfies DuplicatingSetting[];


### PR DESCRIPTION
Added ZAU Center and TRACONs mapping for ATC duplication settings.

### 🔗 Your VATSIM ID

1634151

### 🔗 Linked Issue

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] 🐞 Bug fix
- [x] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

Add ZAU Center and TRACONs to ATC duplication
