### PR TITLE
feat: Extrapolate aircraft positions based on last known location, heading and groundspeed

### DIFF
--- a/app/components/map/layers/MapAircraftList.vue
+++ b/app/components/map/layers/MapAircraftList.vue
@@ -305,7 +305,8 @@ let init = false;
 
 const visibleSet = useThrottleFn(setVisiblePilots, 1000);
 
-const debouncedUpdate = useThrottleFn(() => {
+
+useRafFn(() => {
     if (!canRender.value) {
         vectorSource.clear();
         linesSource.clear();
@@ -320,14 +321,12 @@ const debouncedUpdate = useThrottleFn(() => {
             tracks: showTracks.value,
         });
     }
-}, 1000/20, true);
+});
 
 useUpdateCallback(['mandatory', 'short', 'extent', updateRelatedSettings], () => {
     if (!init) return;
     visibleSet();
 });
-
-watch([getShownPilots, canRender, showTracks, renderedPilots], debouncedUpdate);
 
 watch(map, val => {
     if (!val) return;

--- a/app/components/map/layers/MapAircraftList.vue
+++ b/app/components/map/layers/MapAircraftList.vue
@@ -320,7 +320,7 @@ const debouncedUpdate = useThrottleFn(() => {
             tracks: showTracks.value,
         });
     }
-}, 1000, true);
+}, 1000/20, true);
 
 useUpdateCallback(['mandatory', 'short', 'extent', updateRelatedSettings], () => {
     if (!init) return;

--- a/app/composables/render/aircraft/index.ts
+++ b/app/composables/render/aircraft/index.ts
@@ -140,8 +140,8 @@ export async function setMapAircraft(settings: {
         }
 
         const coordinates = (isSelfFlight && dataStore.vatsim.selfCoordinate.value)
-            ? dataStore.vatsim.selfCoordinate.value.coordinate
-            : [aircraft.longitude, aircraft.latitude];
+            ? extrapolateCoordinates(dataStore.vatsim.selfCoordinate.value.coordinate, aircraft.heading, aircraft.groundspeed, aircraft.last_updated)
+            : extrapolateCoordinates([aircraft.longitude, aircraft.latitude], aircraft.heading, aircraft.groundspeed, aircraft.last_updated);
 
         const heading = (isSelfFlight && dataStore.vatsim.selfCoordinate.value)
             ? dataStore.vatsim.selfCoordinate.value.heading
@@ -210,4 +210,22 @@ export async function setMapAircraft(settings: {
             delete aircraftState[feature.getId() as number];
         }
     }
+}
+
+function extrapolateCoordinates(coordinates: Coordinate, heading: number, groundspeed: number, last_updated: string): Coordinate {
+    const lastUpdateTime = new Date(last_updated).getTime();
+    const currentTime = Date.now();
+    const deltaTimeHours = (currentTime - lastUpdateTime) / (1000 * 60 * 60);
+
+    const distanceNauticalMiles = groundspeed * deltaTimeHours;
+    const distanceDegrees = distanceNauticalMiles / 60;
+
+    const headingRadians = degreesToRadians(heading);
+
+    const [lon, lat] = coordinates;
+
+    const deltaLat = distanceDegrees * Math.cos(headingRadians);
+    const deltaLon = distanceDegrees * Math.sin(headingRadians) / Math.cos(degreesToRadians(lat));
+
+    return [lon + deltaLon, lat + deltaLat];
 }

--- a/app/composables/render/storage.ts
+++ b/app/composables/render/storage.ts
@@ -293,12 +293,13 @@ export function setVatsimMandatoryData(mandatoryData: VatsimMandatoryData) {
     if (hasActivePilotFilter()) mandatoryData.pilots = mandatoryData.pilots.filter(x => vatsim.data.pilots.value.some(y => y.cid === x[0]));
 
     vatsim.mandatoryData.value = {
-        pilots: mandatoryData.pilots.map(([cid, lon, lat, icon, heading]) => {
+        pilots: mandatoryData.pilots.map(([cid, lon, lat, icon, heading, groundspeed, last_updated]) => {
             const cidString = cid.toString();
             if (data.keyedPilots.value?.[cidString]) {
                 data.keyedPilots.value[cidString].longitude = lon;
                 data.keyedPilots.value[cidString].latitude = lat;
                 data.keyedPilots.value[cidString].heading = heading;
+                data.keyedPilots.value[cidString].groundspeed = groundspeed;
             }
 
             return {
@@ -307,6 +308,8 @@ export function setVatsimMandatoryData(mandatoryData: VatsimMandatoryData) {
                 latitude: lat,
                 icon,
                 heading,
+                groundspeed,
+                last_updated,
             };
         }),
         controllers: mandatoryData.controllers.map(([cid, callsign, frequency, facility]) => ({

--- a/app/types/data/vatsim.ts
+++ b/app/types/data/vatsim.ts
@@ -214,13 +214,13 @@ export type VatsimMandatoryData = {
     timestamp: string;
     timestampNum: number;
     serverTime: number;
-    pilots: [cid: VatsimPilot['cid'], longitude: VatsimPilot['longitude'], latitude: VatsimPilot['latitude'], icon: AircraftIcon, heading: number][];
+    pilots: [cid: VatsimPilot['cid'], longitude: VatsimPilot['longitude'], latitude: VatsimPilot['latitude'], icon: AircraftIcon, heading: number, groundspeed: number, last_updated: string][];
     controllers: [VatsimController['cid'], VatsimController['callsign'], VatsimController['frequency'], VatsimController['facility']][];
     atis: VatsimMandatoryData['controllers'];
 };
 
 export type VatsimMandatoryConvertedData = {
-    pilots: Required<Pick<VatsimPilot, 'cid' | 'longitude' | 'latitude' | 'icon' | 'heading'>>[];
+    pilots: Required<Pick<VatsimPilot, 'cid' | 'longitude' | 'latitude' | 'icon' | 'heading' | 'groundspeed' | 'last_updated'>>[];
     controllers: Pick<VatsimController, 'cid' | 'callsign' | 'frequency' | 'facility'>[];
     atis: VatsimMandatoryConvertedData['controllers'];
 };

--- a/app/utils/server/vatsim/update.ts
+++ b/app/utils/server/vatsim/update.ts
@@ -86,7 +86,7 @@ export function updateVatsimMandatoryDataStorage() {
 
     for (const pilot of data.pilots) {
         const coords = [pilot.longitude, pilot.latitude];
-        newData.pilots.push([pilot.cid, coords[0], coords[1], getAircraftIcon(pilot).icon, pilot.heading]);
+        newData.pilots.push([pilot.cid, coords[0], coords[1], getAircraftIcon(pilot).icon, pilot.heading, pilot.groundspeed, pilot.last_updated]);
     }
 
     // Maybe no need to implement


### PR DESCRIPTION
- Extending the mandatoryData of VatsimPilots by groundspeed and last_updated timestamp
- Implement function on render to alter the pilots coordinates based on extrapolation function
- Increase render refresh rate

### 🔗 Your VATSIM ID

1432278

### 🔗 Linked Issue

-

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] 🐞 Bug fix
- [x] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

I like how flightradar24 and planefinder seem to extrapolate aircraft positions for a smoother movement on the map. It's very well done there, although it's not perfect (sometimes you can spot the aircraft "jumping" when new data comes in). However, I thought it's a very cool UX feature and thought this could be a cool addition to vatsim-radar 2.

My implementation is by far not perfect, but it's a start and I wanted to get early input on this, before I spend time on something where you say you don't want it at all. 

# Open issues in this PR

- [ ] Aircrafts wobble when they get updated, this needs some smoothing
- [ ] There's room for improvement to reduce "aircraft jumps" on data updates
    1. Perhaps the most regular cause of aicraft jumps is when they're turning. To solve this, storie the last data of an aircraft and continue with the same turn rate that it had between the last two updates
    2. Also speed changes can be extrapolated to further reduce jumping aircrafts
- [ ] The current implementation may not be really performant since I just span up the refreshrate from 1fps to 20

As general question: I'm not sure how to handle ground traffic. Currently (especially at intersections), traffic just taxi over grass until they snap into their updated position. That's extremely ugly and I'm thinking of restricting the fluid motion to airborne traffic.  It's almost impossible to extrapolate ground movement as headings and speeds change quite rapidly and I believe we hit a technical limitation that's splitting realworld from Vatsim ^^