### PR TITLE
Add ZLC Mapping for ATC Duplication

### DIFF
--- a/app/utils/server/vatsim/atc-duplicating.ts
+++ b/app/utils/server/vatsim/atc-duplicating.ts
@@ -267,6 +267,24 @@ export const duplicatingSettings = [
         },
     },
     /**
+    * @description ZLC Center and TRACONs
+    * @author 1378019
+    */
+    {
+        regex: /^(SLC|BOI|BZN|BIL|GTF|MSO|MUO|HLN|TWF)(_\w{0,3})?_(CTR|TMU|APP|DEP)$/,
+        mapping: {
+            SLC: 'SLC_APP',
+            BOI: 'BOI_APP',
+            BZN: 'BZN_APP',
+            BIL: 'BIL_APP',
+            GTF: 'GTF_APP',
+            MSO: 'MSO_APP',
+            MUO: 'MUO_APP',
+            HLN: 'HLN_APP',
+            TWF: 'TWF_APP',
+        },
+    },
+    /**
     * @description CZYZ FIR Terminal Sectors
     * @author 1401686 and 1448618
     */


### PR DESCRIPTION
### 🔗 Your VATSIM ID

`1378019`

### 🔗 Linked Issue


### ❓ Type of change


- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [x] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

Adds Salt Lake Center and underlying TRACONs ATC Duplication Regex in line with other existing ARTCCs
