### PR TITLE
Add MMEX ACC TMA duplicating for VATMEX

### DIFF
--- a/app/utils/backend/vatsim/atc-duplicating.ts
+++ b/app/utils/backend/vatsim/atc-duplicating.ts
@@ -301,4 +301,26 @@ export const duplicatingSettings = [
             VOK: 'VOK_APP',
         },
     },
+/**
+     * @description MMEX ACC and TMA sectors
+     * @author YOUR_CID
+     */
+    {
+        regex: /^MMEX(\_\w{0,3})?\_CTR$/,
+        mapping: {
+            'MMMX': 'MMMX_APP',
+            'MMGL': 'MMGL_APP',
+            'MMPR': 'MMPR_APP',
+            'MMLO': 'MMLO_APP',
+            'MMMM': 'MMMM_APP',
+            'MMOX': 'MMOX_APP',
+            'MMVR': 'MMVR_APP',
+            'MMTM': 'MMTM_APP',
+            'MMSP': 'MMSP_APP',
+            'MMQT': 'MMQT_APP',
+            'MMZH': 'MMZH_APP',
+            'MMZO': 'MMZO_APP',
+            'MMAA': 'MMAA_APP',
+        },
+    },
 ] satisfies DuplicatingSetting[];

--- a/app/utils/backend/vatsim/atc-duplicating.ts
+++ b/app/utils/backend/vatsim/atc-duplicating.ts
@@ -303,7 +303,7 @@ export const duplicatingSettings = [
     },
 /**
      * @description MMEX ACC and TMA sectors
-     * @author YOUR_CID
+     * @author 1523823
      */
     {
         regex: /^MMEX(\_\w{0,3})?\_CTR$/,


### PR DESCRIPTION
### 🔗 Your VATSIM ID
1523823

### ❓ Type of change
Add MMEX ACC TMA duplicating for VATMEX

- [ √] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description
Adds top-down TMA rendering for Mexico ACC (MMEX_CTR). When MMEX_CTR or its sub-sectors connect, the 13 TMA boundaries within MMEX airspace will automatically display on the map. VATMEX uses vatSys, similar to Australia/NZ. SimAware TRACON data already exists for all these TMAs.