### PR TITLE
Adds CMH E/W sectors

### DIFF
--- a/app/utils/server/vatsim/atc-duplicating.ts
+++ b/app/utils/server/vatsim/atc-duplicating.ts
@@ -433,8 +433,8 @@ export const duplicatingSettings = [
     {
         regex: /^(CMH|DAY)(_\w{0,3})?_(APP)$/,
         mapping: {
-            CMH East: 'CMH_N_APP',
-            CMH West: 'DAY_M_APP',
+            'CMH East': 'CMH_N_APP',
+            'CMH West': 'DAY_M_APP',
         },
     }
 

--- a/app/utils/server/vatsim/atc-duplicating.ts
+++ b/app/utils/server/vatsim/atc-duplicating.ts
@@ -426,5 +426,16 @@ export const duplicatingSettings = [
             CUN: 'MMUN_APP',
         },
     },
+    /**
+     * @description CMH TRACON
+     * @author 1283146 and 1049778
+     */
+    {
+        regex: /^(CMH|DAY)(_\w{0,3})?_(APP)$/,
+        mapping: {
+            CMH East: 'CMH_N_APP',
+            CMH West: 'DAY_M_APP',
+        },
+    }
 
 ] satisfies DuplicatingSetting[];


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1049778

### 🔗 Linked Issue

N/A

### ❓ Type of change


- [ ] 🐞 Bug fix
- [x] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

This PR adds CMH E/W areas to ATC Duplicating to properly display which areas any single controller has.