### PR TITLE
Add Samara FIR ATC duplicating

### DIFF
--- a/app/utils/server/vatsim/atc-duplicating.ts
+++ b/app/utils/server/vatsim/atc-duplicating.ts
@@ -288,7 +288,7 @@ export const duplicatingSettings = [
         mapping: {
             'Samara APP': 'UWWW_APP',
             'Ufa APP': 'UWUU_APP',
-            'Kazan APP': 'UWKD_APP'
+            'Kazan APP': 'UWKD_APP',
         },
     },
 ] satisfies DuplicatingSettingV2[] as DuplicatingSettingV2[];

--- a/app/utils/server/vatsim/atc-duplicating.ts
+++ b/app/utils/server/vatsim/atc-duplicating.ts
@@ -280,4 +280,15 @@ export const duplicatingSettings = [
             'CMH West': 'DAY_M_APP',
         },
     },
+    {
+        description: 'UWWW FIR APP Sectors',
+        authorCid: 1306046,
+        prefixes: ['UWWW'],
+        suffixes: ['CTR'],
+        mapping: {
+            'Samara APP': 'UWWW_APP',
+            'Ufa APP': 'UWUU_APP',
+            'Kazan APP': 'UWKD_APP'
+        },
+    },
 ] satisfies DuplicatingSettingV2[] as DuplicatingSettingV2[];


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1306046

### 🔗 Linked Issue

No linked issues

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] 🐞 Bug fix
- [x] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

Add Samara FIR ATC duplicating
Duplicating will be used by UWWW_CTR split sectors to actively show ownership of APP sectors outside of boundaries of CTR split.