### PR TITLE
Update extensions for ZMA and ZTL

### DIFF
--- a/app/utils/server/vatsim/atc-duplicating.ts
+++ b/app/utils/server/vatsim/atc-duplicating.ts
@@ -41,12 +41,10 @@ export const duplicatingSettings = [
     {
         description: 'ZMA TRACON',
         authorCid: 1275389,
-        prefixes: ['MIA', 'ZMA', 'TPA', 'PBI', 'RSW', 'NQX', 'HST', 'ZMO'],
+        prefixes: ['ZMA', 'TPA', 'RSW', 'NQX', 'HST', 'ZMO'],
         suffixes: ['CTR', 'TMU', 'APP', 'DEP'],
         mapping: {
-            'MIA TRACON': 'MIA_D_DEP',
             'TPA TRACON': 'TPA_L_APP',
-            'PBI TRACON': 'PBI_B_DEP',
             'RSW TRACON': 'RSW_W_APP',
             'NQX RATCF': 'NQX_B_APP',
             'NQX RAPCON': 'NQX_B_APP',
@@ -146,6 +144,9 @@ export const duplicatingSettings = [
         mapping: {
             AGS: 'AGS_APP',
             GSO: 'GSO_APP',
+            AHN: 'AHN_APP',
+            CSG: 'CSG_APP',
+            MCN: 'MCN_APP',
         },
     },
     {


### PR DESCRIPTION
Removed 'MIA' and 'PBI' from ZMA TRACON prefixes and added 'AHN', 'CSG', and 'MCN' to the mapping. A80 always covers AHN CSG and MCN during preestablished hours and should be permitted as extensions

### 🔗 Your VATSIM ID

<!-- 1443689 -->

### 🔗 Linked Issue



### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ x] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

As discussed under v2 chat, suggestions for duplication based on ops for ZMA's and A80 tracons
