### PR TITLE
Add ATC duplication logic for Japan

### DIFF
--- a/app/utils/server/storage.ts
+++ b/app/utils/server/storage.ts
@@ -148,6 +148,7 @@ export interface DatasetSector {
     fullName: string;
     frequency: string;
     callsign: string;
+    region?: string;
 }
 
 export interface RadarDataAirline {

--- a/app/utils/server/vatsim/update.ts
+++ b/app/utils/server/vatsim/update.ts
@@ -367,14 +367,24 @@ export async function updateSectorsData() {
     const nzSectors = $fetch('https://raw.githubusercontent.com/vatSys/new-zealand-dataset/refs/heads/master/Sectors.xml', {
         responseType: 'text',
     });
+    const jpSectors = $fetch('https://vatjpn.org/media/external/vatsim-radar/Sectors.xml', {
+        responseType: 'text',
+    });
 
     const au = xmlParser.parse(await auSectors);
     const nz = xmlParser.parse(await nzSectors);
-    radarStorage.vatsim.sectorsDataset = [...au.Sectors.Sector, ...nz.Sectors.Sector].map((sector: Record<string, any>) => ({
+    const jp = xmlParser.parse(await jpSectors);
+
+    radarStorage.vatsim.sectorsDataset = [
+        ...au.Sectors.Sector.map((sector: any) => ({ ...sector, region: 'AU' })),
+        ...nz.Sectors.Sector.map((sector: any) => ({ ...sector, region: 'NZ' })),
+        ...jp.Sectors.Sector.map((sector: any) => ({ ...sector, region: 'JP' })),
+    ].map((sector: Record<string, any>) => ({
         fullName: sector.FullName,
         name: sector.Name,
         callsign: sector.Callsign,
         frequency: sector.Frequency,
+        region: sector.region,
     }));
 }
 

--- a/app/utils/server/worker/data-worker.ts
+++ b/app/utils/server/worker/data-worker.ts
@@ -1,7 +1,6 @@
 import type { BARS, BARSShort, VatsimStorage } from '../storage';
 import { radarStorage } from '../storage';
 import type {
-    VatsimBookingAtc,
     VatsimData,
     VatsimLiveDataMap,
 } from '~/types/data/vatsim';

--- a/app/utils/server/worker/data-worker.ts
+++ b/app/utils/server/worker/data-worker.ts
@@ -18,6 +18,7 @@ import { defineCronJob, getVATSIMIdentHeaders } from '~/utils/server';
 import { initWholeBunchOfBackendTasks, navigraphUpdating } from '~/utils/server/tasks';
 import { prisma } from '~/utils/server/prisma';
 
+import { getFacilityByCallsign } from '~/utils/shared/vatsim';
 import type { RadarNotam } from '~/utils/shared/vatsim';
 import { getTransceiverData } from '~/utils/server/vatsim';
 
@@ -293,9 +294,13 @@ defineCronJob('* * * * * *', async () => {
         });
 
         const length = radarStorage.vatsim.data!.controllers.length;
+        const onlineCallsigns = new Set(radarStorage.vatsim.data!.controllers.map(x => x.callsign));
 
         const allowedDuplicatingFacilities = ['FSS', 'CTR', 'APP', 'DEP'];
         const allowedDuplicatingSectors = radarStorage.vatsim.sectorsDataset.filter(x => allowedDuplicatingFacilities.some(y => x.callsign.endsWith(y)));
+
+        const auNzSectors = allowedDuplicatingSectors.filter(x => x.region === 'AU' || x.region === 'NZ' || !x.region);
+        const jpSectors = allowedDuplicatingSectors.filter(x => x.region === 'JP');
 
         for (let i = 0; i < length; i++) {
             const controller = radarStorage.vatsim.data!.controllers[i];
@@ -330,7 +335,8 @@ defineCronJob('* * * * * *', async () => {
                 }
             }
 
-            const duplicatedSectors = allowedDuplicatingSectors.filter(x => {
+            // 1. Process AU/NZ duplication (Standard logic)
+            const duplicatedSectors = auNzSectors.filter(x => {
                 const freq = parseFloat(x.frequency).toString();
 
                 return controller.text_atis?.some(
@@ -354,6 +360,50 @@ defineCronJob('* * * * * *', async () => {
                     duplicated: true,
                     duplicatedBy: controller.callsign,
                 });
+            }
+
+            // VATJPN sector duplication
+            if (jpSectors.length > 0 && controller.text_atis?.length) {
+                const atisText = controller.text_atis.join(' ');
+                const mainFreqCanon = parseFloat(controller.frequency).toString();
+
+                const extendedJpSectors = jpSectors.filter(s => {
+                    const nameRegex = new RegExp(`\\b${ s.name }\\b`, 'i');
+                    return nameRegex.test(atisText);
+                });
+
+                if (extendedJpSectors.length > 0) {
+                    const validFrequencies = new Set(extendedJpSectors.map(s => parseFloat(s.frequency).toString()));
+                    validFrequencies.add(mainFreqCanon);
+
+                    for (const sector of extendedJpSectors) {
+                        const sectorFreqCanon = parseFloat(sector.frequency).toString();
+                        if (sectorFreqCanon === mainFreqCanon || sector.frequency === controller.frequency) {
+                            continue;
+                        }
+
+                        const pairRegex = new RegExp(`\\b${ sector.name }\\b\\s+\\b(1\\d{2}\\.\\d{1,3})\\b`, 'i');
+                        const match = atisText.match(pairRegex);
+
+                        if (match) {
+                            const atisFreq = match[1];
+                            const atisFreqCanon = parseFloat(atisFreq).toString();
+                            const targetFrequency = validFrequencies.has(atisFreqCanon) ? atisFreq : controller.frequency;
+
+                            if (sector.callsign === controller.callsign) continue;
+                            if (onlineCallsigns.has(sector.callsign)) continue;
+
+                            radarStorage.vatsim.data.controllers.push({
+                                ...controller,
+                                callsign: sector.callsign,
+                                frequency: targetFrequency,
+                                facility: getFacilityByCallsign(sector.callsign),
+                                duplicated: true,
+                                duplicatedBy: controller.callsign,
+                            });
+                        }
+                    }
+                }
             }
         }
 

--- a/app/utils/server/worker/data-worker.ts
+++ b/app/utils/server/worker/data-worker.ts
@@ -211,7 +211,7 @@ defineCronJob('* * * * * *', async () => {
             rating: 1,
             server: '',
             visual_range: 1,
-            text_atis: ['RJDG_N 133.550', 'F04', 'F15 127.500'],
+            text_atis: ['RJBB 120.25'],
             last_updated: '',
             logon_time: '',
         });*/
@@ -414,7 +414,9 @@ defineCronJob('* * * * * *', async () => {
                         if (match) {
                             const atisFreq = match[1];
                             const atisFreqCanon = parseFloat(atisFreq).toString();
-                            const targetFrequency = validFrequencies.has(atisFreqCanon) ? atisFreq : controller.frequency;
+                            const targetFrequency = validFrequencies.has(atisFreqCanon)
+                                ? parseFloat(atisFreq).toFixed(3)
+                                : controller.frequency;
 
                             if (sector.callsign === controller.callsign) continue;
                             if (onlineCallsigns.has(sector.callsign)) continue;

--- a/app/utils/server/worker/data-worker.ts
+++ b/app/utils/server/worker/data-worker.ts
@@ -299,8 +299,16 @@ defineCronJob('* * * * * *', async () => {
         const allowedDuplicatingFacilities = ['FSS', 'CTR', 'APP', 'DEP'];
         const allowedDuplicatingSectors = radarStorage.vatsim.sectorsDataset.filter(x => allowedDuplicatingFacilities.some(y => x.callsign.endsWith(y)));
 
-        const auNzSectors = allowedDuplicatingSectors.filter(x => x.region === 'AU' || x.region === 'NZ' || !x.region);
-        const jpSectors = allowedDuplicatingSectors.filter(x => x.region === 'JP');
+        const auNzSectors: typeof allowedDuplicatingSectors = [];
+        const jpSectors: typeof allowedDuplicatingSectors = [];
+
+        for (const sector of allowedDuplicatingSectors) {
+            if (sector.region === 'JP') {
+                jpSectors.push(sector);
+            } else if (sector.region === 'AU' || sector.region === 'NZ' || !sector.region) {
+                auNzSectors.push(sector);
+            }
+        }
 
         for (let i = 0; i < length; i++) {
             const controller = radarStorage.vatsim.data!.controllers[i];

--- a/app/utils/server/worker/data-worker.ts
+++ b/app/utils/server/worker/data-worker.ts
@@ -1,6 +1,7 @@
 import type { BARS, BARSShort, VatsimStorage } from '../storage';
 import { radarStorage } from '../storage';
 import type {
+    VatsimBookingAtc,
     VatsimData,
     VatsimLiveDataMap,
 } from '~/types/data/vatsim';
@@ -201,6 +202,20 @@ defineCronJob('* * * * * *', async () => {
         const updateTimestamp = new Date(radarStorage.vatsim.data.general.update_timestamp!).getTime();
         radarStorage.vatsim.data.general.update_timestamp = new Date().toISOString();
 
+        /*        radarStorage.vatsim.data!.controllers.push({
+            cid: 123,
+            name: 'Test',
+            callsign: 'RJDG_CTR',
+            frequency: '122.800',
+            facility: 1,
+            rating: 1,
+            server: '',
+            visual_range: 1,
+            text_atis: ['RJDG_N 133.550', 'F04', 'F15 127.500'],
+            last_updated: '',
+            logon_time: '',
+        });*/
+
         delete radarStorage.vatsim.data.general.version;
         delete radarStorage.vatsim.data.general.connected_clients;
 
@@ -305,7 +320,8 @@ defineCronJob('* * * * * *', async () => {
         for (const sector of allowedDuplicatingSectors) {
             if (sector.region === 'JP') {
                 jpSectors.push(sector);
-            } else if (sector.region === 'AU' || sector.region === 'NZ' || !sector.region) {
+            }
+            else if (sector.region === 'AU' || sector.region === 'NZ' || !sector.region) {
                 auNzSectors.push(sector);
             }
         }
@@ -355,19 +371,21 @@ defineCronJob('* * * * * *', async () => {
                     );
             });
 
-            if (!duplicatedSectors) continue;
+            if (duplicatedSectors?.length) {
+                for (const sector of duplicatedSectors) {
+                    const freq = parseFloat(sector.frequency).toString();
+                    if (freq === controller.frequency || sector.frequency === controller.frequency) continue;
 
-            for (const sector of duplicatedSectors) {
-                const freq = parseFloat(sector.frequency).toString();
-                if (freq === controller.frequency || sector.frequency === controller.frequency) continue;
+                    radarStorage.vatsim.data.controllers.push({
+                        ...controller,
+                        callsign: sector.callsign,
+                        frequency: sector.frequency,
+                        duplicated: true,
+                        duplicatedBy: controller.callsign,
+                    });
+                }
 
-                radarStorage.vatsim.data.controllers.push({
-                    ...controller,
-                    callsign: sector.callsign,
-                    frequency: sector.frequency,
-                    duplicated: true,
-                    duplicatedBy: controller.callsign,
-                });
+                continue;
             }
 
             // VATJPN sector duplication

--- a/docs/guide/duplicating.md
+++ b/docs/guide/duplicating.md
@@ -14,6 +14,16 @@ followed.
 In such case, controller is duplicated as-is, excluding **callsign** and **frequency** - those are changed to target
 sector.
 
+## Japan
+
+- Data is fetched from Sectors.xml: https://vatjpn.org/media/external/vatsim-radar/Sectors.xml
+- Rules are only applied to _CTR, _APP and _DEP
+- Controller's ATIS should include: `Name` and `Frequency` of duplicated sector separated by spaces. For example, `N47 133.55` or `Extending N47 133.550`
+- The written frequency must match either the controller's primary frequency or the default frequency of any duplicated sector that is also explicitly being extended. If it doesn't match, it falls back to the controller's primary frequency.
+
+In such case, controller is duplicated as-is, excluding **callsign** and **frequency** - those are changed to target sector.
+However, duplication will be skipped if the frequency of the duplicated sector matches the controller's primary frequency to prevent duplicate overlays.
+
 ## Hardcoded data
 
 Data is hard coded - extending is allowed for specified callsigns. Controller ATIS should include text of sections below


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1767126

### 🔗 Linked Issue

No linked issues

### ❓ Type of change

- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement (improve something existing)
- [x] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

This PR adds sector duplication support for the Japan (VATJPN) division, allowing online controllers to cover subsectors by listing them in their ATIS.

### Adding VATJPN's Sectors.xml as a duplication source

- Fetches Japan sectors from the official VATJPN XML source (`https://vatjpn.org/media/external/vatsim-radar/Sectors.xml`) alongside Australia and New Zealand.

- Adds an optional `region` property to the in-memory sector dataset to tag sectors (`'AU'`, `'NZ'`, `'JP'`) based on their XML source.

- Filters out AU/NZ and any sectors that are not JP (as a fallback) to process them in the original duplication loop, leaving the existing AU/NZ duplication logic completely untouched and free of side effects.

### Parsing Logic for Japan

For Japanese sectors, duplication is handled by a custom matching routine to match VATJPN operations:

- Matches `sectorName frequency` pairs separated by spaces (e.g., `N47 133.55`). This follows the same concept as AU/NZ, but allows a more flexible frequency selection. The duplication frequency can either be the active controller's primary frequency or the default XML frequency of any extended sector, depending on what is written in the ATIS. As long as a frequency matches any of the extended sectors, it can be shared among other sectors.

For example, given these XML sectors:
```xml
<Sector Frequency="133.550" Callsign="A_CTR" Name="AAA"></Sector>
<Sector Frequency="123.900" Callsign="B_CTR" Name="BBB"></Sector>
<Sector Frequency="127.150" Callsign="C_CTR" Name="CCC"></Sector>
<Sector Frequency="120.250" Callsign="D_APP" Name="DDD"></Sector>
```

If a controller logs in as `A_1_CTR` on `133.550` with the following ATIS:
```
Alpha Control
Covering AAA
Extending BBB 123.9, CCC 123.9, DDD 133.55
```

`A_1_CTR` (AAA) is the active position, rendering with frequency `133.550`.
`B_CTR` (BBB) is duplicated with frequency `123.900`.
`C_CTR` (CCC) is duplicated with frequency `123.900` (its written frequency of `123.9` is validated because it matches `BBB`'s default XML frequency).
`D_APP` (DDD) is duplicated with frequency `133.550` (its written frequency of `133.55` is validated because it matches the controller's primary frequency).

If a controller accidentally writes a frequency that does not match any of their extended sectors or their primary frequency, the sector will still be duplicated, but its frequency will fall back to the controller's primary frequency.

- Skips duplication if the sector's default frequency matches the controller's primary frequency. This prevents duplicate overlays over the controller's active main sector (even when the logged-in callsign does not match the one specified in Sectors.xml).

- Allows CTR controllers to extend both CTR and APP sectors. This works dynamically based on the XML data (similar to the AU/NZ format) rather than relying on hardcoded preset mappings.

- Assigns duplicated approach sectors their proper `APP` facility type (via getFacilityByCallsign) instead of inheriting the parent CTR's facility type. This resolves the CTR-to-APP visibility issue and ensures these extended approach positions correctly render as dashed TRACON boundaries.


