### PR TITLE
Added ATC duplication for ZMP (DSM TRACON only)

### DIFF
--- a/app/utils/server/vatsim/atc-duplicating.ts
+++ b/app/utils/server/vatsim/atc-duplicating.ts
@@ -241,6 +241,15 @@ export const duplicatingSettings = [
         },
     },
     {
+        description: 'ZMP Center and TRACONs',
+        authorCid: 1240191,
+        prefixes: ['MSP'],
+        suffixes: ['CTR'],
+        mapping: {
+            DSM: 'DSM_APP',
+        },
+    },
+    {
         description: 'ACC Curitiba (SBCW)',
         authorCid: 1233530,
         prefixes: ['SBCW'],


### PR DESCRIPTION
### 🔗 Your VATSIM ID

1240191

### 🔗 Linked Issue

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [x] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

Added ATC duplication rules for ZMP. DSM approach covers KDSM/KALO and about half of it sits under ZAU airspace, which can cause confusion.