### PR TITLE
Add approach label color settings

### DIFF
--- a/app/composables/render/airports/layers/airport-style.ts
+++ b/app/composables/render/airports/layers/airport-style.ts
@@ -224,8 +224,13 @@ export function setAirportStyle(layer: VectorLayer) {
                         defaultTransparency = getSelectedColorTransparencyFromSettings(isUir ? 'uirs' : 'firs') ?? 1;
                     }
 
-                    const textColor = getSelectedColorFromSettings('approachText', true) || defaultColor;
-                    const textTransparency = getSelectedColorTransparencyFromSettings('approachText') ?? 1;
+                    const floorTransparency = defaultTransparency < 0.3 ? 0.3 : defaultTransparency;
+
+                    const approachTextColor = getSelectedColorFromSettings('approachText', true, true);
+                    const textColor = approachTextColor ?? defaultColor;
+                    const textTransparency = approachTextColor != null
+                        ? (getSelectedColorTransparencyFromSettings('approachText') ?? 1)
+                        : floorTransparency;
                     const bgColor = getSelectedColorFromSettings('approachBg') ?? getCurrentThemeHexColor('darkGray900');
 
                     styleCache[strokeKey] = new Style({
@@ -234,7 +239,7 @@ export function setAirportStyle(layer: VectorLayer) {
                             text: '',
                             placement: 'point',
                             overflow: true,
-                            fill: getCachedFill((store.bookingOverride || properties.isBooked) ? `rgba(${ getCurrentThemeRgbColor('lightGray200').join(',') }, ${ defaultTransparency < 0.3 ? 0.3 : defaultTransparency })` : own ? getCurrentThemeHexColor('lightGray200') : isDuplicated ? `rgba(${ defaultColor }, 1)` : `rgba(${ textColor }, ${ textTransparency })`),
+                            fill: getCachedFill((store.bookingOverride || properties.isBooked) ? `rgba(${ getCurrentThemeRgbColor('lightGray200').join(',') }, ${ floorTransparency })` : own ? getCurrentThemeHexColor('lightGray200') : isDuplicated ? `rgba(${ defaultColor }, 1)` : `rgba(${ textColor }, ${ textTransparency })`),
                             backgroundFill: own ? getCachedFill(`rgb(${ defaultColor })`) : getCachedFill(bgColor),
                             backgroundStroke: new Stroke({
                                 width: 2,

--- a/app/composables/render/airports/layers/airport-style.ts
+++ b/app/composables/render/airports/layers/airport-style.ts
@@ -224,14 +224,18 @@ export function setAirportStyle(layer: VectorLayer) {
                         defaultTransparency = getSelectedColorTransparencyFromSettings(isUir ? 'uirs' : 'firs') ?? 1;
                     }
 
+                    const textColor = getSelectedColorFromSettings('approachText', true) || defaultColor;
+                    const textTransparency = getSelectedColorTransparencyFromSettings('approachText') ?? 1;
+                    const bgColor = getSelectedColorFromSettings('approachBg') ?? getCurrentThemeHexColor('darkGray900');
+
                     styleCache[strokeKey] = new Style({
                         text: new Text({
                             font: getTextFont('caption-medium'),
                             text: '',
                             placement: 'point',
                             overflow: true,
-                            fill: getCachedFill((store.bookingOverride || properties.isBooked) ? `rgba(${ getCurrentThemeRgbColor('lightGray200').join(',') }, ${ defaultTransparency < 0.3 ? 0.3 : defaultTransparency })` : own ? getCurrentThemeHexColor('lightGray200') : `rgb(${ defaultColor }, ${ isDuplicated ? 1 : defaultTransparency < 0.3 ? 0.3 : defaultTransparency })`),
-                            backgroundFill: own ? getCachedFill(`rgb(${ defaultColor })`) : getCachedFill(getCurrentThemeHexColor('darkGray900')),
+                            fill: getCachedFill((store.bookingOverride || properties.isBooked) ? `rgba(${ getCurrentThemeRgbColor('lightGray200').join(',') }, ${ defaultTransparency < 0.3 ? 0.3 : defaultTransparency })` : own ? getCurrentThemeHexColor('lightGray200') : isDuplicated ? `rgba(${ defaultColor }, 1)` : `rgba(${ textColor }, ${ textTransparency })`),
+                            backgroundFill: own ? getCachedFill(`rgb(${ defaultColor })`) : getCachedFill(bgColor),
                             backgroundStroke: new Stroke({
                                 width: 2,
                                 lineDash: properties.isTWR ? [4, 8] : undefined,

--- a/app/composables/settings/colors.ts
+++ b/app/composables/settings/colors.ts
@@ -78,8 +78,8 @@ export function getSelectedColorTransparencyFromSettings(color: SettingsColorTyp
     return setting ? setting.transparency : null;
 }
 
-export function getSelectedColorFromSettings(color: SettingsColorType, raw?: boolean) {
-    const setting = getColorValueByKey(`map.preferences.colors.default.${ color }` as any) as UserMapSettingsColor | null;
+export function getSelectedColorFromSettings(color: SettingsColorType, raw?: boolean, noDefault?: boolean) {
+    const setting = getColorValueByKey(`map.preferences.colors.default.${ color }` as any, noDefault) as UserMapSettingsColor | null;
 
     return setting ? getColorFromSettings(setting, raw) : null;
 }

--- a/app/composables/settings/v2/items/general/appearance/colors.ts
+++ b/app/composables/settings/v2/items/general/appearance/colors.ts
@@ -58,6 +58,20 @@ export const settingsItemAppearanceColors = globalComputed(() => makeSettingsIte
         value: colorValue('map.preferences.colors.default.approachBookings'),
         onChange: value => setColorByKey('map.preferences.colors.default.approachBookings', value as UserMapSettingsColor),
     },
+    approachText: {
+        type: 'color',
+        title: 'Approach label (text)',
+        defaultColor: colorDefault('map.preferences.colors.default.approachText'),
+        value: colorValue('map.preferences.colors.default.approachText'),
+        onChange: value => setColorByKey('map.preferences.colors.default.approachText', value as UserMapSettingsColor),
+    },
+    approachBg: {
+        type: 'color',
+        title: 'Approach label (background)',
+        defaultColor: colorDefault('map.preferences.colors.default.approachBg'),
+        value: colorValue('map.preferences.colors.default.approachBg'),
+        onChange: value => setColorByKey('map.preferences.colors.default.approachBg', value as UserMapSettingsColor),
+    },
     firs: {
         type: 'color',
         title: 'FIR (ARTCC)',

--- a/app/composables/settings/v2/sections.ts
+++ b/app/composables/settings/v2/sections.ts
@@ -194,6 +194,8 @@ export const getSettingsSections = () => {
                             items: [
                                 items.appearance.colors.approach,
                                 items.appearance.colors.approachBookings,
+                                items.appearance.colors.approachText,
+                                items.appearance.colors.approachBg,
                                 items.appearance.colors.firs,
                                 items.appearance.colors.centerBookings,
                                 items.appearance.colors.uirs,

--- a/app/composables/settings/v2/utils.ts
+++ b/app/composables/settings/v2/utils.ts
@@ -324,10 +324,12 @@ export function getColorByKey<K extends SettingsKeysWithDefault>(path: K) {
     );
 }
 
-export function getColorValueByKey<K extends SettingsKeysWithDefault>(path: K) {
+export function getColorValueByKey<K extends SettingsKeysWithDefault>(path: K, noDefault?: boolean) {
     const colorPath = changeColorPath(path);
 
-    return getKeyedValueFromSettings(colorPath) ?? getKeyedValueFromSettings(path) ?? settingsDefaultValues[path];
+    const value = getKeyedValueFromSettings(colorPath, true) ?? getKeyedValueFromSettings(path, true);
+
+    return value ?? (noDefault ? undefined : settingsDefaultValues[path]);
 }
 
 export function setColorByKey<K extends DeepKeyOfSettings>(path: K, value: DeepValueOfSetting<UserSettingsV2, K> | undefined) {

--- a/app/composables/settings/v2/utils.ts
+++ b/app/composables/settings/v2/utils.ts
@@ -107,6 +107,8 @@ const _settingsDefaultValues = {
     'map.preferences.colors.default.centerText': { color: 'lightGray500' },
     'map.preferences.colors.default.centerBg': { color: 'darkGray500' },
     'map.preferences.colors.default.approach': { color: 'red300' },
+    'map.preferences.colors.default.approachText': { color: 'red300' },
+    'map.preferences.colors.default.approachBg': { color: 'darkGray900' },
     'map.preferences.colors.default.approachBookings': { color: 'purple300', transparency: 0.7 },
     'map.preferences.colors.default.centerBookings': { color: 'lightGray400', transparency: 0.07 },
     'map.preferences.colors.default.staffedAirport': 1,

--- a/app/utils/server/handlers/map-settings.ts
+++ b/app/utils/server/handlers/map-settings.ts
@@ -12,6 +12,8 @@ export interface UserMapSettingsColors {
     centerText?: UserMapSettingsColor;
     centerBg?: UserMapSettingsColor;
     approach?: UserMapSettingsColor;
+    approachText?: UserMapSettingsColor;
+    approachBg?: UserMapSettingsColor;
     staffedAirport?: number;
     defaultAirport?: number;
     approachBookings?: UserMapSettingsColor;

--- a/app/utils/settings/validate.ts
+++ b/app/utils/settings/validate.ts
@@ -113,6 +113,8 @@ const themeColorsSchema = partialObject({
     centerText: colorSchema,
     centerBg: colorSchema,
     approach: colorSchema,
+    approachText: colorSchema,
+    approachBg: colorSchema,
     staffedAirport: transparencySchema,
     defaultAirport: transparencySchema,
     approachBookings: colorSchema,

--- a/docs/ai/structure.md
+++ b/docs/ai/structure.md
@@ -147,6 +147,8 @@ For new UI, prefer these primitives and existing feature/component patterns befo
 - `modules/styles.ts` uses those tokens to generate SCSS/CSS color variables in `app/scss/colors.scss`.
 - `app/scss/variables.scss` defines semantic SCSS aliases such as `$appColor`, `$brandPrimary`, and `$navigraphColor`.
 - User-facing map color defaults live in `app/composables/settings/v2/utils.ts`; some values can be explicit hex colors instead of named palette tokens.
+- Adding a user-customizable map color requires touching the whole chain: `UserMapSettingsColors` type in `app/utils/server/handlers/map-settings.ts`, `themeColorsSchema` in `app/utils/settings/validate.ts`, defaults in `app/composables/settings/v2/utils.ts`, the settings item in `app/composables/settings/v2/items/general/appearance/colors.ts`, its section entry in `app/composables/settings/v2/sections.ts`, and consumption at render time via `getSelectedColorFromSettings`/`getSelectedColorTransparencyFromSettings` (`app/composables/settings/colors.ts`). Defaults from `settingsDefaultValues` are applied at render via `getColorValueByKey`, so an unset user value falls back to the default, not to the render-side fallback.
+- Examples of render-side consumers: FIR/UIR sector + label styling in `app/composables/render/sectors/style.ts` (`centerText`/`centerBg`), tracon/approach circle + label styling in `app/composables/render/airports/layers/airport-style.ts` (`approach`/`approachText`/`approachBg`).
 
 ## Client Composables
 


### PR DESCRIPTION
 ### 🔗 Your VATSIM ID                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                 
1359999                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                 
  ### 🔗 Linked Issue                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                 
  Closes #1651                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                 
  ### ❓ Type of change                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                 
  - [x] 🐞 Bug fix                                                                                                                                                                                                                                                                                                               
  - [x] 👌 Enhancement (improve something existing)                                                                                                                                                                                                                                                                              
  - [ ] ✨ New functionality                                                                                                                                                                                                                                                                                                     
  - [ ] 🧹 Technical change (refactoring, updates and other improvements)                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                 
  ### 📚 Description                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                 
  Adds **"Approach label (text)"** and **"Approach label (background)"** color settings to Airspace Colors, mirroring the existing FIR label settings (`centerText`/`centerBg`), and fixes tracon labels not following transparency settings.                                                                                    
                                                                                                                                                                                                                                                                                                                                 
  **Before:**                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                 
  - Tracon label text borrowed the "Approach tracon/circle" color, with transparency clamped to a minimum of 0.3 — selecting anything below 0.3 had no visible effect.                                                                                                                                                           
  - Tracon label background was hardcoded to theme `darkGray900` and ignored color and transparency settings entirely.                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                 
  **After:**                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                 
  - Label text follows the new `approachText` setting, with its transparency fully honored (clamp removed — same behavior as FIR labels).                                                                                                                                                                                        
  - Label background follows the new `approachBg` setting, including transparency.                                                                                                                                                                                                                                               
  - Defaults (`red300` text, `darkGray900` background) match the previous rendered appearance in both themes, so nothing changes for users who don't touch the new settings.                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                 
  Unchanged: own-ATC labels (approach-colored background), booked labels, and labels for tracons duplicated by CTR/FSS (FIR/UIR-colored text).                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                 
  Note: label text is now decoupled from the circle color — users who customized "Approach tracon/circle" will need to set "Approach label (text)" to recolor label text, which is what #1651 requests.                                                                                                                          
                                                                                                                                                                                                                                                                                                                                 
  Touched files: settings type (`map-settings.ts`), validation schema (`validate.ts`), defaults (`settings/v2/utils.ts`), settings UI items + section (`colors.ts`, `sections.ts`), and label rendering (`airport-style.ts`).                                                                                                    
                                                                                                                                                                                                                                                                                                                                 
  Verified in the local dev stack: new settings appear under Airspace Colors, text/background follow color and transparency (including below 0.3), defaults render identically to before.                                                                                                                                        
                                                                                                                                                                                                                                                                                                                              